### PR TITLE
bump to librosa 0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ torchaudio==0.7.0
 apex==0.9.10.dev0
 torch==1.7.0
 webrtcvad==2.0.10
-librosa==0.6.2
+librosa==0.8.0
 gdown==3.12.2
 tensorflow
 matplotlib==3.3.3


### PR DESCRIPTION
parallel_wavegan wants librosa 0.8.0 when trying to resolve dependencies. haven't noticed any major problems using that version so far.